### PR TITLE
update windows runners from 2019 to 2022

### DIFF
--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-2019]
+        os: [ubuntu-latest, macos-13, windows-2022]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/testpypi-win.yml
+++ b/.github/workflows/testpypi-win.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The Windows Server 2019 runner image will be fully unsupported by June 30, 2025.

Updated 2019 runner image to 2022 on the workflow files [.github/workflows/testpypi-win.yml](https://github.com/scanoss/scanoss-winnowing.py/blob/c824a5916bf2dae9f22c28606e195fc62aca8eab/.github/workflows/testpypi-win.yml#L41) and [.github/workflows/python-publish-pypi.yml](https://github.com/scanoss/scanoss-winnowing.py/blob/c824a5916bf2dae9f22c28606e195fc62aca8eab/.github/workflows/python-publish-pypi.yml#L81)