### PR TITLE
 fix(publish):SP-4152-upgrade-cibuildwheel-rate-limit

### DIFF
--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14, windows-2022]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -89,7 +89,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/.github/workflows/testpypi-linux.yml
+++ b/.github/workflows/testpypi-linux.yml
@@ -25,7 +25,7 @@ jobs:
 
       # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_BEFORE_BUILD_LINUX: curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.github/workflows/testpypi-mac.yml
+++ b/.github/workflows/testpypi-mac.yml
@@ -24,7 +24,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_SKIP: pp*

--- a/.github/workflows/testpypi-win.yml
+++ b/.github/workflows/testpypi-win.yml
@@ -50,7 +50,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
           CIBW_SKIP: pp*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `--skip-headers` incorrectly identifying continuation lines inside multi-line import blocks
 ### Added
 - Added `scanoss.yml` workflow file
+- Upgraded `cibuildwheel` from v2.20.0 to v3.4.0 to fix 429 rate-limit errors during wheel builds across all platforms
 
 ## [0.7.0] - 2025-12-17
 ### Added


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded wheel build tooling across CI workflows to a newer release.
  * Updated workflow checkout action versions and adjusted Linux build environment settings.

* **Documentation**
  * Added a changelog entry recording the build tooling and workflow updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->