### PR TITLE
ci(deps): let Dependabot watch the Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Python dependencies (requirements / pyproject)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## What

Adds a `pip` ecosystem entry to `.github/dependabot.yml` (created the file).

## Why

Dependabot had no Python ecosystem configured here, so `pyproject.toml` / `requirements.txt` were never getting version-update PRs. Security alerts still fire, but routine bumps never land, which means every upgrade arrives as a hand-applied patch after an alert.

## Notes

- `pip` is the right ecosystem for this repo (no lock file; manifests are resolved directly).
- Weekly on Monday, `chore` prefix, 10 open-PR limit — same shape as the other Python repos.
- Config only. No dependency versions change in this PR.
